### PR TITLE
Fix firestore external

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,6 @@
     "start:docs:dev": "vite serve docs --config vite.docs.config.js",
     "test": "vitest run --config vite.test.config.js",
     "watch:test": "vitest watch --config vite.test.config.js"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-firestore",
-  "version": "0.6.0",
+  "version": "0.7.0-beta.0",
   "license": "MIT",
   "main": "./dist/lib.umd.js",
   "module": "./dist/lib.es.js",

--- a/vite.lib.config.js
+++ b/vite.lib.config.js
@@ -25,14 +25,7 @@ export default defineConfig({
     },
 
     rollupOptions: {
-      // make sure to externalize deps that shouldn't be bundled
-      // into your library
-      external: ["firebase", "react"],
-      output: {
-        // Provide global variables to use in the UMD build
-        // for externalized deps
-        globals: { "firebase": "firebase", "react": "react" },
-      },
+      external: ["firebase/firestore", "react"],
     },
   },
 })


### PR DESCRIPTION
TIL that

1) You don't need to set the `rollupOptions.output.globals` aliases for ESM modules to work. That's purely a UMD thing.
2) I'm not sure if you really want the globals to be variables? When operating on the Yarn3/Webpack branch (#3) I had to assign them to the import strings so that the consumer resolver would provide the right peer dependencies back to `use-firestore`. At this point I can't really understand _why_ you'd ever want to have global variables for a package... don't we always want the resolver to resolve them?

Anyway, small tweak here needed for the externals.