### PR TITLE
Allow unsubscribe to be missing

### DIFF
--- a/lib/useDocs.ts
+++ b/lib/useDocs.ts
@@ -77,7 +77,11 @@ export function useDocs<T extends object>(query: Query<DocumentData>) {
           if (listeners.length > 0) return
 
           const unsubscribe = unsubscribeByKey[key]
+
+          if (!unsubscribe) return
+
           delete unsubscribeByKey[key]
+
           unsubscribe()
         }, 100)
       }


### PR DESCRIPTION
It's OK if unsubscribe is missing, that's to be expected if multiple hooks with the same query unmount at the same time.