### PR TITLE
Association have associations

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "semi": false,
   "tabWidth": 2,
-  "quoteProps": "preserve"
+  "quoteProps": "preserve",
+  "printWidth": 65
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,12 @@
       "name": "Debug Current Test File",
       "skipFiles": ["<node_internals>/**", "**/node_modules/**"],
       "program": "${workspaceRoot}/node_modules/vitest/vitest.mjs",
-      "args": ["related", "--config", "vite.test.config.js", "${relativeFile}"],
+      "args": [
+        "related",
+        "--config",
+        "vite.test.config.js",
+        "${relativeFile}"
+      ],
       "smartStep": true,
       "console": "integratedTerminal"
     }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ data at the component level.
   - [`useDoc` hook with optimistic updates](#usedoc-hook-with-optimistic-updates)
   - [`useDocs` hook](#usedocs-hook)
   - [`deleteDocs` function](#deletedocs-function)
+  - [Nested delete](#nested-delete)
+- [Warnings](#warnings)
 - [Why](#why)
 - [Todo](#todo)
 
@@ -116,7 +118,7 @@ If you want to take this "denormalized" approach check out [Anish Karandikar's](
 | Realtime updates                                  | ✅            | ✅                                  |
 | Fetch a sub-graph of documents with a single read | ❌            | ✅                                  |
 | Re-use queries application-wide                   | ✅            | ❌                                  |
-| Throws errors                                     | ✅            | ❌ require manual error handling    |
+| Throws errors                                     | ✅            | ❌ requires manual error handling   |
 | Memory efficient derived state on top of queries  | ✅            | ❌ each hook returns unique objects |
 | Optimistic updates                                | ✅            | ✅ via the Firebase SDK?            |
 | Batch document reads to avoid N+1 problem         | ✅            | ❌                                  |
@@ -285,6 +287,8 @@ await deleteDocs(
 
 The above code will also delete any documents in the "highlights" collection which have the `tagId` field set to `"tag123"`, before deleting `/tags/tag123`.
 
+### Nested delete
+
 You can also go multiple levels deep with your deletions. For example, if every "highlight" belongs to a "tag" and every "document" has many "highlights", when you delete a tag you want to:
 
 1. Delete all of the highlights associated with that tag
@@ -314,7 +318,7 @@ await deleteDocs(
 )
 ```
 
-**Warnings**:
+## Warnings
 
 The `deleteDocs` function will do all of the deletions and updates in a series of [batched writes](https://firebase.google.com/docs/firestore/manage-data/transactions#batched-writes). However note that if there are more than 500 updates and/or writes to do, `deleteDocs` will do several batched writes. If any batch fails this can create inconsistencies in your data.
 
@@ -396,7 +400,7 @@ In this scenario, we get a few nice performance benefits:
 
 Additionally, if we were to use that `tags` array as a prop to a memoized component, it would only trigger a re-render when the collection actually changes, regardless of how many times the parent component renders.
 
-### Todo
+## Todo
 
 - [x] Unsubscribe from query when no more listeners are left
 - [x] Add tests

--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ function Repo({ repoId }) {
 
 ### `useDocs` hook
 
+The `useDocs` hook obviously can be used to fetch multiple documents by ID in a single call....
+
 ```tsx
 import { useDocs } from "use-firestore"
 import { collection, getFirestore } from "firebase/firestore"
@@ -235,6 +237,12 @@ return (
     ))}
   </>
 )
+```
+
+... however it's most useful for efficient querying of 1:N relationships in a tree of React components:
+
+```
+[example needed]
 ```
 
 ### `deleteDocs` function
@@ -287,7 +295,7 @@ await deleteDocs(
 
 The above code will also delete any documents in the "highlights" collection which have the `tagId` field set to `"tag123"`, before deleting `/tags/tag123`.
 
-### Nested delete
+### Nested **delete**
 
 You can also go multiple levels deep with your deletions. For example, if every "highlight" belongs to a "tag" and every "document" has many "highlights", when you delete a tag you want to:
 

--- a/docs/index.tsx
+++ b/docs/index.tsx
@@ -4,6 +4,10 @@ import { render } from "react-dom"
 import * as HomePage from "./HomePage.docs"
 
 render(
-  <DocsApp icon="fire" logo="Firestore Hooks" docs={[HomePage]} />,
+  <DocsApp
+    icon="fire"
+    logo="Firestore Hooks"
+    docs={[HomePage]}
+  />,
   document.getElementById("root")
 )

--- a/lib/DocsProvider.tsx
+++ b/lib/DocsProvider.tsx
@@ -22,14 +22,19 @@ type DocsProviderProps = {
   debug?: boolean
 }
 
-export function DocsProvider({ children, debug = false }: DocsProviderProps) {
+export function DocsProvider({
+  children,
+  debug = false,
+}: DocsProviderProps) {
   const [services] = useState(() => ({
     queryService: new QueryService(debug),
     collectionService: new CollectionService(debug),
   }))
 
   return (
-    <DocsContext.Provider value={services}>{children}</DocsContext.Provider>
+    <DocsContext.Provider value={services}>
+      {children}
+    </DocsContext.Provider>
   )
 }
 
@@ -37,7 +42,9 @@ export function useQueryService(hookName: string) {
   const context = useContext(DocsContext)
 
   if (!isInitialized(context)) {
-    throw new Error(`${hookName} cannot be used outside of a DocsProvider`)
+    throw new Error(
+      `${hookName} cannot be used outside of a DocsProvider`
+    )
   }
 
   return context.queryService
@@ -47,7 +54,9 @@ export function useCollectionService(hookName: string) {
   const context = useContext(DocsContext)
 
   if (!isInitialized(context)) {
-    throw new Error(`${hookName} cannot be used outside of a DocsProvider`)
+    throw new Error(
+      `${hookName} cannot be used outside of a DocsProvider`
+    )
   }
 
   return context.collectionService

--- a/lib/deleteDocs.test.ts
+++ b/lib/deleteDocs.test.ts
@@ -1,6 +1,17 @@
 import { waitFor } from "@testing-library/react"
-import { collection, doc, getDoc, getFirestore } from "firebase/firestore"
-import { describe, it, expect, beforeAll, afterAll } from "vitest"
+import {
+  collection,
+  doc,
+  getDoc,
+  getFirestore,
+} from "firebase/firestore"
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+} from "vitest"
 import {
   andDeleteAssociatedDocs,
   andRemoveFromIds,
@@ -20,12 +31,17 @@ describe("deleteDocs", () => {
 
   it("removes the doc id from the arrays in a related collection", async () => {
     const { tag } = await setUpTag(testApp)
-    const { repo } = await setUpRepo(testApp, { tagIds: [tag.id] })
+    const { repo } = await setUpRepo(testApp, {
+      tagIds: [tag.id],
+    })
 
     await deleteDocs(
       collection(getFirestore(testApp), "tags"),
       [tag.id],
-      andRemoveFromIds(collection(getFirestore(testApp), "repos"), "tagIds")
+      andRemoveFromIds(
+        collection(getFirestore(testApp), "repos"),
+        "tagIds"
+      )
     )
 
     await waitFor(async () => {
@@ -41,31 +57,6 @@ describe("deleteDocs", () => {
     )
 
     expect(getRepoResult.data()?.tagIds).toHaveLength(0)
-  })
-
-  it("deletes child docs", async () => {
-    const { highlight, tag } = await setUpHighlight(testApp)
-
-    await deleteDocs(
-      collection(getFirestore(testApp), "tags"),
-      [tag.id],
-      andDeleteAssociatedDocs(
-        collection(getFirestore(testApp), "highlights"),
-        "tagId"
-      )
-    )
-
-    const getTagResult = await getDoc(
-      doc(getFirestore(testApp), "tags", tag.id)
-    )
-
-    expect(getTagResult.exists()).toBe(false)
-
-    const getHighlightResult = await getDoc(
-      doc(getFirestore(testApp), "highlights", highlight.id)
-    )
-
-    expect(getHighlightResult.exists()).toBe(false)
   })
 
   it("deletes child docs", async () => {
@@ -128,9 +119,8 @@ describe("deleteDocs", () => {
       doc(getFirestore(testApp), "documents", document.id)
     )
 
-    const highlightIds = getDocumentResult.data()?.highlightIds as
-      | string[]
-      | undefined
+    const highlightIds = getDocumentResult.data()
+      ?.highlightIds as string[] | undefined
 
     expect(highlightIds).toContain("defg789")
     expect(highlightIds).not.toContain(highlight.id)

--- a/lib/deleteDocs.ts
+++ b/lib/deleteDocs.ts
@@ -1,10 +1,15 @@
-import type { CollectionReference, WriteBatch } from "firebase/firestore"
+import type {
+  CollectionReference,
+  Firestore,
+  WriteBatch,
+} from "firebase/firestore"
 import { getDocs, query, where, writeBatch, doc } from "firebase/firestore"
 
 type Association = {
   __type: "remove-from-ids" | "delete-associated-docs"
   collection: CollectionReference
   field: string
+  associations: Association[]
 }
 
 export async function deleteDocs(
@@ -12,20 +17,52 @@ export async function deleteDocs(
   idsToDelete: string[],
   ...associations: Association[]
 ) {
-  let currentBatch = writeBatch(collection.firestore)
+  const batches = new BatchOfBatches(collection.firestore)
 
-  const batches: WriteBatch[] = []
+  await addAssociationOperationsToBatches(batches, associations, idsToDelete)
 
-  let operationCount = 0
-
-  function incrementOperation() {
-    operationCount++
-    if (operationCount < 500) return
-
-    batches.push(currentBatch)
-    currentBatch = writeBatch(collection.firestore)
-    operationCount = 0
+  for (const id of idsToDelete) {
+    const ref = doc(collection, id)
+    batches.currentBatch.delete(ref)
+    batches.incrementOperation()
   }
+
+  for (const batch of batches.batches) {
+    await batch.commit()
+  }
+
+  if (batches.operationCount > 0) {
+    await batches.currentBatch.commit()
+  }
+}
+
+class BatchOfBatches {
+  firestore: Firestore
+  currentBatch: WriteBatch
+  batches: WriteBatch[] = []
+  operationCount = 0
+
+  constructor(firestore: Firestore) {
+    this.firestore = firestore
+    this.currentBatch = writeBatch(firestore)
+  }
+
+  incrementOperation() {
+    this.operationCount++
+    if (this.operationCount < 500) return
+
+    this.batches.push(this.currentBatch)
+    this.currentBatch = writeBatch(this.firestore)
+    this.operationCount = 0
+  }
+}
+
+async function addAssociationOperationsToBatches(
+  batches: BatchOfBatches,
+  associations: Association[],
+  idsToDelete: string[]
+) {
+  if (idsToDelete.length < 1) return
 
   for (const association of associations) {
     if (association.__type === "delete-associated-docs") {
@@ -36,9 +73,17 @@ export async function deleteDocs(
         )
       )
 
+      const associatedIds = associatedDocs.docs.map((snapshot) => snapshot.id)
+
+      await addAssociationOperationsToBatches(
+        batches,
+        association.associations,
+        associatedIds
+      )
+
       for (const associatedDoc of associatedDocs.docs) {
-        currentBatch.delete(associatedDoc.ref)
-        incrementOperation()
+        batches.currentBatch.delete(associatedDoc.ref)
+        batches.incrementOperation()
       }
     } else if (association.__type === "remove-from-ids") {
       const docsReferencingDeletedIds = await getDocs(
@@ -57,26 +102,14 @@ export async function deleteDocs(
         }
         const scrubbedIds = idsToScrub.filter((id) => !idsToDelete.includes(id))
 
-        currentBatch.update(doc.ref, { [association.field]: scrubbedIds })
-        incrementOperation()
+        batches.currentBatch.update(doc.ref, {
+          [association.field]: scrubbedIds,
+        })
+        batches.incrementOperation()
       }
     } else {
       throw new Error(`Unknown association type: ${String(association.__type)}`)
     }
-  }
-
-  for (const id of idsToDelete) {
-    const ref = doc(collection, id)
-    currentBatch.delete(ref)
-    incrementOperation()
-  }
-
-  for (const batch of batches) {
-    await batch.commit()
-  }
-
-  if (operationCount > 0) {
-    await currentBatch.commit()
   }
 }
 
@@ -88,16 +121,19 @@ export function andRemoveFromIds(
     __type: "remove-from-ids",
     collection,
     field: key,
+    associations: [],
   }
 }
 
 export function andDeleteAssociatedDocs(
   collection: CollectionReference,
-  key: string
+  key: string,
+  ...associations: Association[]
 ): Association {
   return {
     __type: "delete-associated-docs",
     collection,
     field: key,
+    associations,
   }
 }

--- a/lib/deleteDocs.ts
+++ b/lib/deleteDocs.ts
@@ -3,7 +3,13 @@ import type {
   Firestore,
   WriteBatch,
 } from "firebase/firestore"
-import { getDocs, query, where, writeBatch, doc } from "firebase/firestore"
+import {
+  getDocs,
+  query,
+  where,
+  writeBatch,
+  doc,
+} from "firebase/firestore"
 
 type Association = {
   __type: "remove-from-ids" | "delete-associated-docs"
@@ -19,7 +25,11 @@ export async function deleteDocs(
 ) {
   const batches = new BatchOfBatches(collection.firestore)
 
-  await addAssociationOperationsToBatches(batches, associations, idsToDelete)
+  await addAssociationOperationsToBatches(
+    batches,
+    associations,
+    idsToDelete
+  )
 
   for (const id of idsToDelete) {
     const ref = doc(collection, id)
@@ -73,7 +83,9 @@ async function addAssociationOperationsToBatches(
         )
       )
 
-      const associatedIds = associatedDocs.docs.map((snapshot) => snapshot.id)
+      const associatedIds = associatedDocs.docs.map(
+        (snapshot) => snapshot.id
+      )
 
       await addAssociationOperationsToBatches(
         batches,
@@ -89,18 +101,26 @@ async function addAssociationOperationsToBatches(
       const docsReferencingDeletedIds = await getDocs(
         query(
           association.collection,
-          where(association.field, "array-contains-any", idsToDelete)
+          where(
+            association.field,
+            "array-contains-any",
+            idsToDelete
+          )
         )
       )
 
       for (const doc of docsReferencingDeletedIds.docs) {
-        const idsToScrub = doc.data()[association.field] as string[]
+        const idsToScrub = doc.data()[
+          association.field
+        ] as string[]
         if (!Array.isArray(idsToScrub)) {
           throw new Error(
             `Field ${association.field} in andRemoveFromIds(collection, "${association.field}") must be an array field.`
           )
         }
-        const scrubbedIds = idsToScrub.filter((id) => !idsToDelete.includes(id))
+        const scrubbedIds = idsToScrub.filter(
+          (id) => !idsToDelete.includes(id)
+        )
 
         batches.currentBatch.update(doc.ref, {
           [association.field]: scrubbedIds,
@@ -108,7 +128,9 @@ async function addAssociationOperationsToBatches(
         batches.incrementOperation()
       }
     } else {
-      throw new Error(`Unknown association type: ${String(association.__type)}`)
+      throw new Error(
+        `Unknown association type: ${String(association.__type)}`
+      )
     }
   }
 }

--- a/lib/makeUninitializedContext.ts
+++ b/lib/makeUninitializedContext.ts
@@ -36,14 +36,18 @@
  * @param message Error message to throw when the context is used before being initialized
  * @returns a proxy object with whatever type you specify
  */
-export function makeUninitializedContext<ContextType>(message: string) {
+export function makeUninitializedContext<ContextType>(
+  message: string
+) {
   return new Proxy(
     {},
     {
       get(target, prop) {
         if (prop === "__isUninitializedContext") return true
 
-        throw new Error(`${message}: tried getting context.${prop.toString()}`)
+        throw new Error(
+          `${message}: tried getting context.${prop.toString()}`
+        )
       },
     }
   ) as ContextType
@@ -70,5 +74,6 @@ type UnititializedContext = Record<string, unknown> & {
  */
 export function isInitialized(value: unknown) {
   if (typeof value !== "object") return true
-  return !(value as UnititializedContext).__isUninitializedContext
+  return !(value as UnititializedContext)
+    .__isUninitializedContext
 }

--- a/lib/serializeQuery.test.ts
+++ b/lib/serializeQuery.test.ts
@@ -19,7 +19,9 @@ describe("serializeQuery", () => {
       )
     )
 
-    expect(serialized).toEqual(`repos?filter=propertyX.in:"a",1,1.5,true,null`)
+    expect(serialized).toEqual(
+      `repos?filter=propertyX.in:"a",1,1.5,true,null`
+    )
   })
 
   it("serializes multiple constraints", () => {
@@ -45,7 +47,9 @@ describe("serializeQuery", () => {
       )
     )
 
-    expect(serialized).toEqual(`stories?order=projectId:asc,title:asc`)
+    expect(serialized).toEqual(
+      `stories?order=projectId:asc,title:asc`
+    )
   })
 
   it("serializes reference values", () => {

--- a/lib/serializeQuery.ts
+++ b/lib/serializeQuery.ts
@@ -22,7 +22,10 @@ export function serializeQuery(query: Query<DocumentData>) {
     const path = _query.path.segments.join("/")
 
     const orders = _query.explicitOrderBy
-      .map(({ dir, field: { segments } }) => `${segments.join("/")}:${dir}`)
+      .map(
+        ({ dir, field: { segments } }) =>
+          `${segments.join("/")}:${dir}`
+      )
       .join(",")
 
     const filters = _query.filters.map((filter) => {
@@ -40,19 +43,26 @@ export function serializeQuery(query: Query<DocumentData>) {
     const parameters = []
 
     if (orders.length) parameters.push(`order=${orders}`)
-    if (filters.length) parameters.push(`filter=${filters.join("&filter=")}`)
+    if (filters.length)
+      parameters.push(`filter=${filters.join("&filter=")}`)
     if (limit != null)
       parameters.push(
         `limit=${serialize(limit)}`,
         `limitType=${serialize(limitType)}`
       )
-    if (startAt != null) parameters.push(`startAt=${serialize(startAt)}`)
-    if (endAt != null) parameters.push(`endAt=${serialize(endAt)}`)
+    if (startAt != null)
+      parameters.push(`startAt=${serialize(startAt)}`)
+    if (endAt != null)
+      parameters.push(`endAt=${serialize(endAt)}`)
 
     return `${path}?${parameters.join("&")}`
   } catch (e) {
     console.error(
-      `Error serializing query:\n${JSON.stringify(_query, null, 4)}`
+      `Error serializing query:\n${JSON.stringify(
+        _query,
+        null,
+        4
+      )}`
     )
 
     throw e
@@ -111,7 +121,10 @@ type Firestore3Query = Query<DocumentData> & {
       segments: string[]
       canonicalString(): string
     }
-    explicitOrderBy: { dir: string; field: { segments: string[] } }[]
+    explicitOrderBy: {
+      dir: string
+      field: { segments: string[] }
+    }[]
     filters: FirestoreFilter[]
     limit: number | null
     startAt: Serializable
@@ -136,7 +149,9 @@ type CompoundFilter = {
   op: keyof typeof SERIALIZED_OPS
 }
 
-function isSingleFilter(filter: FirestoreFilter): filter is SingleFilter {
+function isSingleFilter(
+  filter: FirestoreFilter
+): filter is SingleFilter {
   return Object.prototype.hasOwnProperty.call(filter, "field")
 }
 
@@ -165,7 +180,9 @@ function serialize(value: Serializable): string {
   }
 
   throw new Error(
-    `use-firestore doesn't know how to serialize ${JSON.stringify(value)}`
+    `use-firestore doesn't know how to serialize ${JSON.stringify(
+      value
+    )}`
   )
 }
 
@@ -187,7 +204,9 @@ const VALUE_OBJECT_KEYS = [
   "referenceValue",
 ]
 
-function isValueObject(object: Record<string, unknown>): object is ValueObject {
+function isValueObject(
+  object: Record<string, unknown>
+): object is ValueObject {
   return VALUE_OBJECT_KEYS.some((key) =>
     Object.prototype.hasOwnProperty.call(object, key)
   )
@@ -197,7 +216,9 @@ type ValuesObject = {
   values: ValueObject[]
 }
 
-function isValuesObject(value: Serializable): value is ValuesObject {
+function isValuesObject(
+  value: Serializable
+): value is ValuesObject {
   if (typeof value !== "object") return false
 
   const values = (value as ValuesObject).values
@@ -220,9 +241,17 @@ function serializeValue(value: ValueObject) {
     return value.referenceValue
   } else {
     throw new Error(
-      `use-firestore can't serialize value object ${JSON.stringify(value)}`
+      `use-firestore can't serialize value object ${JSON.stringify(
+        value
+      )}`
     )
   }
 }
 
-type Serializable = string | number | null | undefined | boolean | ValuesObject
+type Serializable =
+  | string
+  | number
+  | null
+  | undefined
+  | boolean
+  | ValuesObject

--- a/lib/test/helpers/connectToEmulators.ts
+++ b/lib/test/helpers/connectToEmulators.ts
@@ -1,14 +1,21 @@
 import fetch from "cross-fetch"
 import { initializeApp } from "firebase/app"
-import { connectFirestoreEmulator, getFirestore } from "firebase/firestore"
+import {
+  connectFirestoreEmulator,
+  getFirestore,
+} from "firebase/firestore"
 
-type SetupTeardownFunction = (callback: () => void | Promise<void>) => void
+type SetupTeardownFunction = (
+  callback: () => void | Promise<void>
+) => void
 
 const FIRESTORE_EMULATOR_HOST = "127.0.0.1"
 const FIRESTORE_EMULATOR_PORT = 5002
 const FIRESTORE_PROJECT = "use-firestore-test"
 
-export const testApp = initializeApp({ projectId: FIRESTORE_PROJECT })
+export const testApp = initializeApp({
+  projectId: FIRESTORE_PROJECT,
+})
 
 export function connectToEmulators(
   beforeAll: SetupTeardownFunction,

--- a/lib/test/helpers/factory.ts
+++ b/lib/test/helpers/factory.ts
@@ -15,7 +15,10 @@ export type Tag = {
 
 let tagCount = 0
 
-export async function setUpTag(app: FirebaseApp, overrides: Partial<Tag> = {}) {
+export async function setUpTag(
+  app: FirebaseApp,
+  overrides: Partial<Tag> = {}
+) {
   tagCount++
 
   const properties = {
@@ -24,7 +27,10 @@ export async function setUpTag(app: FirebaseApp, overrides: Partial<Tag> = {}) {
     ...overrides,
   }
 
-  const ref = await addDoc(collection(getFirestore(app), "tags"), properties)
+  const ref = await addDoc(
+    collection(getFirestore(app), "tags"),
+    properties
+  )
 
   const tag = {
     id: ref.id,
@@ -64,7 +70,10 @@ export async function setUpRepo(
     ...overrides,
   }
 
-  const ref = await addDoc(collection(getFirestore(app), "repos"), properties)
+  const ref = await addDoc(
+    collection(getFirestore(app), "repos"),
+    properties
+  )
 
   const repo = {
     id: ref.id,

--- a/lib/test/helpers/factory.ts
+++ b/lib/test/helpers/factory.ts
@@ -103,10 +103,14 @@ export async function setUpHighlight(
   const properties = {
     start: 0,
     end: 100,
+    tagId: tag.id,
     ...overrides,
   }
 
-  const ref = await addDoc(collection(getFirestore(app), "tags"), properties)
+  const ref = await addDoc(
+    collection(getFirestore(app), "highlights"),
+    properties
+  )
 
   const highlight = {
     id: ref.id,
@@ -114,4 +118,33 @@ export async function setUpHighlight(
   } as Highlight
 
   return { highlight, tag }
+}
+
+export type Document = {
+  id: string
+  text: string
+  highlightIds: string[]
+}
+
+export async function setUpDocument(
+  app: FirebaseApp,
+  overrides: Partial<Document> = {}
+) {
+  const properties = {
+    text: "some text",
+    highlightIds: [],
+    ...overrides,
+  }
+
+  const ref = await addDoc(
+    collection(getFirestore(app), "documents"),
+    properties
+  )
+
+  const document = {
+    id: ref.id,
+    ...properties,
+  } as Document
+
+  return { document }
 }

--- a/lib/test/helpers/mockSubscriptions.ts
+++ b/lib/test/helpers/mockSubscriptions.ts
@@ -13,7 +13,9 @@ import { testApp } from "./connectToEmulators"
 
 const originalOnSnapshot = Firestore.onSnapshot
 
-type SnapshotHandler = (snapshot: DocumentSnapshot | QuerySnapshot) => void
+type SnapshotHandler = (
+  snapshot: DocumentSnapshot | QuerySnapshot
+) => void
 
 /**
  * Mocks the Firestore onSnapshot function

--- a/lib/useDocs.test.tsx
+++ b/lib/useDocs.test.tsx
@@ -19,7 +19,10 @@ import {
   beforeEach,
 } from "vitest"
 import { DocsProvider } from "./DocsProvider"
-import { connectToEmulators, testApp } from "./test/helpers/connectToEmulators"
+import {
+  connectToEmulators,
+  testApp,
+} from "./test/helpers/connectToEmulators"
 import { mockSubscriptions } from "./test/helpers/mockSubscriptions"
 import { useDoc, useDocs } from "./useDocs"
 import { useQuery } from "./useQuery"
@@ -27,7 +30,8 @@ import type { Repo, Tag } from "~/test/helpers/factory"
 import { setUpRepo, setUpTag } from "~/test/helpers/factory"
 
 vi.mock("firebase/firestore", async (importOriginal) => {
-  const original: { onSnapshot(this: void): void } = await importOriginal()
+  const original: { onSnapshot(this: void): void } =
+    await importOriginal()
 
   return {
     ...original,
@@ -52,7 +56,10 @@ describe("useDocs", () => {
     })
 
     const { result } = renderHook(
-      () => useDoc<Repo>(doc(getFirestore(testApp), "repos", repo.id)),
+      () =>
+        useDoc<Repo>(
+          doc(getFirestore(testApp), "repos", repo.id)
+        ),
       {
         wrapper: DocsProvider,
       }
@@ -74,7 +81,9 @@ describe("useDocs", () => {
       ownerId: "whitney",
     })
 
-    const freshDoc = await getDoc(doc(getFirestore(testApp), "repos", repo.id))
+    const freshDoc = await getDoc(
+      doc(getFirestore(testApp), "repos", repo.id)
+    )
 
     expect(freshDoc.data()).toMatchObject({
       ownerId: "whitney",
@@ -123,8 +132,17 @@ describe("useDocs", () => {
     )
   }
 
-  function Repo({ slug, tagIds }: { slug: string; tagIds: string[] }) {
-    const tags = useDocs<Tag>(collection(getFirestore(testApp), "tags"), tagIds)
+  function Repo({
+    slug,
+    tagIds,
+  }: {
+    slug: string
+    tagIds: string[]
+  }) {
+    const tags = useDocs<Tag>(
+      collection(getFirestore(testApp), "tags"),
+      tagIds
+    )
 
     if (!tags) return null
 
@@ -144,7 +162,9 @@ describe("useDocs", () => {
     const { tag: tag1 } = await setUpTag(testApp)
     const { tag: tag2 } = await setUpTag(testApp)
 
-    const { repo: repo1 } = await setUpRepo(testApp, { tagIds: [tag1.id] })
+    const { repo: repo1 } = await setUpRepo(testApp, {
+      tagIds: [tag1.id],
+    })
     await setUpRepo(testApp, {
       ownerId: repo1.ownerId,
       tagIds: [tag2.id],
@@ -156,20 +176,31 @@ describe("useDocs", () => {
 
     const { onSnapshot } = mockSubscriptions()
 
-    const { getAllByRole } = render(<ListRepos ownerId={repo1.ownerId} />, {
-      wrapper: DocsProvider,
-    })
+    const { getAllByRole } = render(
+      <ListRepos ownerId={repo1.ownerId} />,
+      {
+        wrapper: DocsProvider,
+      }
+    )
 
-    await waitFor(() => expect(getAllByRole("listitem")).toHaveLength(3))
+    await waitFor(() =>
+      expect(getAllByRole("listitem")).toHaveLength(3)
+    )
 
     expect(onSnapshot).toHaveBeenCalledTimes(2)
   })
 
   it("re-subscribes a collection when we add new ids", async () => {
-    const { tag: tag1 } = await setUpTag(testApp, { text: "one" })
-    const { tag: tag2 } = await setUpTag(testApp, { text: "two" })
+    const { tag: tag1 } = await setUpTag(testApp, {
+      text: "one",
+    })
+    const { tag: tag2 } = await setUpTag(testApp, {
+      text: "two",
+    })
 
-    const { repo } = await setUpRepo(testApp, { tagIds: [tag1.id] })
+    const { repo } = await setUpRepo(testApp, {
+      tagIds: [tag1.id],
+    })
 
     const { onSnapshot } = mockSubscriptions()
 
@@ -180,13 +211,18 @@ describe("useDocs", () => {
       }
     )
 
-    await waitFor(() => expect(getAllByRole("listitem")).toHaveLength(1))
+    await waitFor(() =>
+      expect(getAllByRole("listitem")).toHaveLength(1)
+    )
 
     expect(onSnapshot).toHaveBeenCalledTimes(2)
 
-    await updateDoc(doc(getFirestore(testApp), "repos", repo.id), {
-      tagIds: [tag1.id, tag2.id],
-    })
+    await updateDoc(
+      doc(getFirestore(testApp), "repos", repo.id),
+      {
+        tagIds: [tag1.id, tag2.id],
+      }
+    )
 
     await waitFor(() => getByText("two"))
 

--- a/lib/useGlobalMemo.ts
+++ b/lib/useGlobalMemo.ts
@@ -65,7 +65,9 @@ export function useGlobalMemo<GeneratedValue>(
   dependencies: Array<Serializable>
 ) {
   if (/\|/.test(cacheKey)) {
-    throw new Error("useGlobalMemo cacheKey cannot use the | character")
+    throw new Error(
+      "useGlobalMemo cacheKey cannot use the | character"
+    )
   }
 
   const serialized = dependencies.map(serialize)
@@ -88,7 +90,13 @@ export function useGlobalMemo<GeneratedValue>(
 /**
  * These are the data types that can be used as dependencies
  */
-type Serializable = object | string | number | null | undefined | boolean
+type Serializable =
+  | object
+  | string
+  | number
+  | null
+  | undefined
+  | boolean
 
 /**
  * Returns a unique string for a given dependency
@@ -102,7 +110,10 @@ function serialize(dependency: Serializable) {
     return address
   }
 
-  if (typeof dependency === "number" && dependency > ADDRESS_START) {
+  if (
+    typeof dependency === "number" &&
+    dependency > ADDRESS_START
+  ) {
     throw new Error(
       `Cannot use ${dependency} as a dependency with useGlobalMemo because it's too large. We use the integers over ${
         ADDRESS_START - 1

--- a/lib/useHookId.ts
+++ b/lib/useHookId.ts
@@ -21,7 +21,11 @@ function isCollectionReference(
   return context.type === "collection"
 }
 
-const IGNORE_FUNCTIONS = ["renderWithHooks", "useState", "Object.useState"]
+const IGNORE_FUNCTIONS = [
+  "renderWithHooks",
+  "useState",
+  "Object.useState",
+]
 
 /**
  * Returns a state string representing a unique ID for a hook, one of:
@@ -33,7 +37,11 @@ const IGNORE_FUNCTIONS = ["renderWithHooks", "useState", "Object.useState"]
  * Does not change unless the hook is unmounted (even if the arguments change).
  */
 export function useHookId(
-  context: Query | DocumentReference | CollectionReference,
+  context:
+    | Query
+    | DocumentReference
+    | CollectionReference
+    | string,
   ids?: string[]
 ): string {
   const { debug } = useQueryService("useHookId")
@@ -43,13 +51,17 @@ export function useHookId(
 
     if (debug) {
       const stack =
-        new Error("Getting stacktrace...").stack?.split("\n").slice(3, 10) ?? []
+        new Error("Getting stacktrace...").stack
+          ?.split("\n")
+          .slice(3, 10) ?? []
 
       let line: string | undefined
       const functionNames: string[] = []
 
       while ((line = stack.shift())) {
-        const functionName = line.match(/ {4}at [^ ]+/)?.[0]?.slice(7)
+        const functionName = line
+          .match(/ {4}at [^ ]+/)?.[0]
+          ?.slice(7)
         if (!functionName) continue
         if (functionName.length < 3) continue
         if (IGNORE_FUNCTIONS.includes(functionName)) continue
@@ -62,7 +74,9 @@ export function useHookId(
     }
 
     if (loc) {
-      if (isDocumentReference(context)) {
+      if (typeof context === "string") {
+        return `${context}@${loc} #${++hookCount}`
+      } else if (isDocumentReference(context)) {
         return `useDoc@${loc} #${++hookCount}`
       } else if (isCollectionReference(context)) {
         return `useDocs@${loc} #${++hookCount}`
@@ -71,11 +85,16 @@ export function useHookId(
       }
     }
 
-    if (isDocumentReference(context)) {
+    if (typeof context === "string") {
+      return `${context} #${++hookCount}`
+    } else if (isDocumentReference(context)) {
       return `useDoc(${context.path}) #${++hookCount}`
     } else if (isCollectionReference(context)) {
-      const idsString = ids && ids.length ? ids.join(",") : "no ids"
-      return `useDocs(${context.path}, [${idsString}]) #${++hookCount}`
+      const idsString =
+        ids && ids.length ? ids.join(",") : "no ids"
+      return `useDocs(${
+        context.path
+      }, [${idsString}]) #${++hookCount}`
     } else {
       return `useQuery(${serializeQuery(context).slice(
         0,

--- a/lib/useQuery.test.ts
+++ b/lib/useQuery.test.ts
@@ -1,9 +1,23 @@
 import { waitFor } from "@testing-library/react"
 import { renderHook } from "@testing-library/react-hooks"
-import { collection, getFirestore, query, where } from "firebase/firestore"
-import { describe, it, expect, beforeAll, afterAll } from "vitest"
+import {
+  collection,
+  getFirestore,
+  query,
+  where,
+} from "firebase/firestore"
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+} from "vitest"
 import { DocsProvider } from "./DocsProvider"
-import { connectToEmulators, testApp } from "./test/helpers/connectToEmulators"
+import {
+  connectToEmulators,
+  testApp,
+} from "./test/helpers/connectToEmulators"
 import { useQuery } from "./useQuery"
 import * as factory from "~/test/helpers/factory"
 import type { Repo } from "~/test/helpers/factory"

--- a/lib/useQuery.ts
+++ b/lib/useQuery.ts
@@ -29,7 +29,9 @@ import { useHookId } from "./useHookId"
  * A subscription to Firestore will be created for each unique query, and the
  * results of the hook will be updated in realtime.
  */
-export function useQuery<T extends { id: string }>(query: Query<DocumentData>) {
+export function useQuery<T extends { id: string }>(
+  query: Query<DocumentData>
+) {
   const [docs, setDocs] = useState<Array<T> | undefined>()
   const hookId = useHookId(query)
   const service = useQueryService("useQuery")
@@ -44,15 +46,13 @@ export function useQuery<T extends { id: string }>(query: Query<DocumentData>) {
       log(hookId, "query changed to", serializeQuery(query))
     }
 
-    const { unregister, cachedResults } = service.registerQueryHook(
-      hookId,
-      query,
-      (docs) => {
+    const { unregister, cachedResults } =
+      service.registerQueryHook(hookId, query, (docs) => {
         setDocs(docs as Array<unknown> as Array<T>)
-      }
-    )
+      })
 
-    if (cachedResults) setDocs(cachedResults as Array<unknown> as Array<T>)
+    if (cachedResults)
+      setDocs(cachedResults as Array<unknown> as Array<T>)
 
     return unregister
   }, [serializeQuery(query)])

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-firestore",
-  "version": "0.12.0-beta.0",
+  "version": "0.12.0-beta.1",
   "license": "MIT",
   "main": "./dist/lib.umd.js",
   "module": "./dist/lib.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-firestore",
-  "version": "0.11.0",
+  "version": "0.12.0-beta.0",
   "license": "MIT",
   "main": "./dist/lib.umd.js",
   "module": "./dist/lib.es.js",


### PR DESCRIPTION
Allows you to go multiple levels deep with the `andDeleteAssociatedDocs` associations.

### Documentation:

Go multiple levels deep with your deletions. For example, if every "highlight" belongs to a "tag" and every "document" has many "highlights", when you delete a tag you want to:

1. Delete all of the highlights associated with that tag
2. Remove all of those highlights from any documents they are referenced in
3. Finally, delete the highlights.

The code for that would look like:

```ts
await deleteDocs(
  collection(getFirestore(app), "tags"),
  [tag.id],
  andDeleteAssociatedDocs(
    collection(getFirestore(app), "highlights"),
    "tagId",
    andRemoveFromIds(
      collection(getFirestore(app), "documents"),
      "highlightIds"
    )
  )
)
```