### PR TITLE
Fix first render cached doc bug

### DIFF
--- a/lib/useDocs.ts
+++ b/lib/useDocs.ts
@@ -122,7 +122,9 @@ export function useDocs<T extends { id: string }>(
   collection: CollectionReference,
   ids: string[]
 ) {
-  const [docs, setDocs] = useState<T[] | undefined>()
+  const [docs, setDocs] = useState<T[] | undefined>(() => {
+    return ids.length < 1 ? [] : undefined
+  })
   const hookId = useHookId(collection, ids)
   const service = useCollectionService("useDoc")
   const firstRenderRef = useRef(true)
@@ -148,18 +150,20 @@ export function useDocs<T extends { id: string }>(
       }
     )
 
-    if (cachedDocs) setDocs(cachedDocs as unknown as T[])
+    if (cachedDocs) {
+      setDocs(cachedDocs as unknown as T[])
+    }
 
     return unregister
   }, [collection.path])
 
   useEffect(() => {
-    setDocs(ids.length < 1 ? [] : undefined)
-
     if (firstRenderRef.current) {
       firstRenderRef.current = false
       return
     }
+
+    setDocs(ids.length < 1 ? [] : undefined)
 
     service.updateDocIds(collection.path, hookId, ids)
   }, [ids.join()])

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-firestore",
-  "version": "0.14.0",
+  "version": "0.15.0-beta.0",
   "license": "MIT",
   "main": "./dist/lib.umd.js",
   "module": "./dist/lib.es.js",


### PR DESCRIPTION
If docs were cached on first render the `useEffect` watching the ids would clear them and they might not never appear.
