### PR TITLE
Allow more than 30 docs from a single collection via `useDocs` and `useDoc`

### DIFF
--- a/lib/ChunkedSnapshotListener.ts
+++ b/lib/ChunkedSnapshotListener.ts
@@ -1,0 +1,200 @@
+import {
+  type CollectionReference,
+  onSnapshot,
+  type QuerySnapshot,
+  query,
+  where,
+  documentId,
+} from "firebase/firestore"
+import { difference } from "./helpers"
+import chunk from "./helpers/chunk"
+import { serializeQuery } from "./serializeQuery"
+
+function red(text: string) {
+  return `\x1b[31m${text}\x1b[0m`
+}
+
+export class ChunkedSnapshotListener {
+  collectionRef: CollectionReference
+  subscribedIds: string[] = []
+  currentIds: string[]
+  chunks: string[][] = []
+  unsubscribes: (() => void)[] = []
+  onSnapshot: (snapshot: QuerySnapshot) => void
+  status: "waiting" | "started" | "stopped" = "waiting"
+  debug: boolean
+
+  constructor(
+    debug: boolean,
+    collectionRef: CollectionReference,
+    initialIds: string[],
+    onSnapshot: (snapshot: QuerySnapshot) => void
+  ) {
+    this.collectionRef = collectionRef
+    this.currentIds = [...initialIds]
+    this.onSnapshot = onSnapshot
+    this.debug = debug
+
+    this.log(
+      "Created waiting chunked listener for",
+      this.collectionRef.path,
+      "with",
+      this.currentIds.length,
+      "ids initially"
+    )
+  }
+
+  log(...args: Parameters<typeof console.log>) {
+    if (!this.debug) return
+    console.log(`${red("use-firestore")} 🔥`, ...args)
+  }
+
+  start() {
+    this.log(
+      "Starting",
+      this.collectionRef.path,
+      "listener, listening to",
+      this.currentIds.length,
+      "ids"
+    )
+    this.status = "started"
+    this.subscribeNewChunks(this.currentIds)
+    this.subscribedIds.push(...this.currentIds)
+  }
+
+  private subscribeNewChunks(ids: string[]) {
+    const newChunks = chunk(ids, 30)
+
+    for (const chunk of newChunks) {
+      const q = query(
+        this.collectionRef,
+        where(documentId(), "in", chunk)
+      )
+      const unsubscribe = onSnapshot(q, this.onSnapshot)
+
+      this.log(
+        "Subscribing to",
+        this.collectionRef.path,
+        "chunk No.",
+        this.chunks.length + 1,
+        serializeQuery(q)
+      )
+
+      this.chunks.push(chunk)
+      this.unsubscribes.push(unsubscribe)
+    }
+  }
+
+  addIds(newIds: string[]) {
+    if (this.status === "stopped") {
+      throw new Error(
+        `Tried to use snapshot listener for ${this.collectionRef.path} but it was shut down`
+      )
+    }
+
+    const idsToSubscribe = difference(newIds, this.subscribedIds)
+
+    if (this.status === "waiting") {
+      this.currentIds.push(...idsToSubscribe)
+
+      this.log(
+        "Ids",
+        newIds,
+        "on",
+        this.collectionRef.path,
+        "added during the waiting period.",
+        idsToSubscribe.length,
+        "are new"
+      )
+
+      return
+    }
+
+    if (idsToSubscribe.length < 1) {
+      this.log(
+        "No new",
+        this.collectionRef.path,
+        "ids in",
+        newIds
+      )
+
+      return
+    }
+
+    this.log(
+      "Will resubscribe after adding ids",
+      newIds,
+      "on",
+      this.collectionRef.path,
+      idsToSubscribe.length,
+      "are new"
+    )
+
+    const lastChunkIndex = this.chunks.length - 1
+    const lastChunk = this.chunks[lastChunkIndex]
+
+    let idsForFutureChunks = idsToSubscribe
+
+    if (lastChunk) {
+      const spaceLeftInLastChunk = 30 - lastChunk.length
+
+      const idsForLastChunk = idsToSubscribe.slice(
+        0,
+        spaceLeftInLastChunk
+      )
+
+      idsForFutureChunks = idsToSubscribe.slice(
+        spaceLeftInLastChunk
+      )
+
+      if (idsForLastChunk.length > 0) {
+        this.resubscribe(lastChunkIndex, [
+          ...this.chunks[lastChunkIndex],
+          ...idsForLastChunk,
+        ])
+      }
+    }
+
+    if (idsForFutureChunks.length > 0) {
+      this.subscribeNewChunks(idsForFutureChunks)
+    }
+
+    this.subscribedIds.push(...idsToSubscribe)
+  }
+
+  private resubscribe(chunkIndex: number, chunk: string[]) {
+    const oldUnsubscribe = this.unsubscribes[chunkIndex]
+
+    oldUnsubscribe()
+
+    const q = query(
+      this.collectionRef,
+      where(documentId(), "in", chunk)
+    )
+
+    const newUnsubscribe = onSnapshot(q, this.onSnapshot)
+
+    this.log(
+      "Resubscribing",
+      this.collectionRef.path,
+      "chunk No.",
+      chunkIndex + 1,
+      serializeQuery(q)
+    )
+
+    this.chunks[chunkIndex] = chunk
+    this.unsubscribes[chunkIndex] = newUnsubscribe
+  }
+
+  shutDown() {
+    this.log(
+      "Shutting down chunked listener for",
+      this.collectionRef.path
+    )
+    for (const unsubscribe of this.unsubscribes) {
+      unsubscribe()
+    }
+
+    this.status = "stopped"
+  }
+}

--- a/lib/CollectionService.ts
+++ b/lib/CollectionService.ts
@@ -274,7 +274,9 @@ export class CollectionService {
     )
 
     this.log(
-      "subscribing to collection snapshots with query:",
+      "subscribing to",
+      collectionPath,
+      "collection snapshots with query:",
       serializeQuery(q),
       "there are",
       collectionSubscriptions.length,

--- a/lib/DocsProvider.tsx
+++ b/lib/DocsProvider.tsx
@@ -25,11 +25,13 @@ const DocsContext = createContext<SubscriptionServices>(
 type DocsProviderProps = {
   children: React.ReactNode
   debug?: boolean
+  testEnv?: boolean
 }
 
 export function DocsProvider({
   children,
   debug = false,
+  testEnv = false,
 }: DocsProviderProps) {
   useEffect(() => {
     if (!debug) return
@@ -37,7 +39,7 @@ export function DocsProvider({
   }, [])
 
   const [services] = useState(() => ({
-    queryService: new QueryService(debug),
+    queryService: new QueryService(debug, testEnv),
     collectionService: new CollectionService(debug),
   }))
 

--- a/lib/QueryService.ts
+++ b/lib/QueryService.ts
@@ -117,10 +117,13 @@ export class QueryService {
           const docs: CachedDocument[] = []
 
           this.log(
+            "query",
             queryKey,
-            "snapshot with",
+            "received snapshot with",
             querySnapshot.size,
-            "docs"
+            "docs for",
+            this.queryListenersByKey[queryKey].length,
+            "listeners"
           )
 
           querySnapshot.forEach((docSnapshot) => {

--- a/lib/QueryService.ts
+++ b/lib/QueryService.ts
@@ -63,7 +63,7 @@ export class QueryService {
     const hasOwner = Boolean(this.ownerByQueryKey[queryKey])
 
     this.log(
-      "registering",
+      "Registering",
       hookId,
       hasOwner ? "⇒ has owner" : "⇒ subscribing..."
     )
@@ -108,7 +108,7 @@ export class QueryService {
      * If no one else is subscribed to this query yet, we'll do it
      */
     const subscribe = () => {
-      this.log("subscribing to query", queryKey)
+      this.log("Subscribing to query", queryKey)
       this.ownerByQueryKey[queryKey] = hookId
 
       const unsubscribeFromQuery = onSnapshot(
@@ -117,7 +117,7 @@ export class QueryService {
           const docs: CachedDocument[] = []
 
           this.log(
-            "query",
+            "Query",
             queryKey,
             "received snapshot with",
             querySnapshot.size,
@@ -156,7 +156,7 @@ export class QueryService {
      * there is one available or otherwise unsubscribe from snapshots.
      */
     const unsubscribe = () => {
-      this.log(hookId, "is unsubscribing from", queryKey)
+      this.log("Hook", hookId, "is unsubscribing from", queryKey)
       // Some other hook is the owner of this query key, there's nothing for us
       // to unsubscribe
       if (this.ownerByQueryKey[queryKey] !== hookId) {
@@ -233,7 +233,7 @@ export class QueryService {
       assignQueryOwnerFunctions.splice(index, 1)
 
       this.log(
-        "now there are",
+        "Now there are",
         assignQueryOwnerFunctions.length,
         "available owners"
       )
@@ -250,6 +250,7 @@ export class QueryService {
       // lots of connections open.
       if (this.ownerByQueryKey[queryKey] === hookId) {
         this.log(
+          "Hook",
           hookId,
           "is unregistering and may unsubscribe in",
           `${UNSUBSCRIBE_DELAY}ms...`
@@ -260,6 +261,7 @@ export class QueryService {
         setTimeout(unsubscribe, UNSUBSCRIBE_DELAY)
       } else {
         this.log(
+          "Hook",
           hookId,
           "is unregistering and it is not the owner,",
           this.ownerByQueryKey[queryKey],

--- a/lib/QueryService.ts
+++ b/lib/QueryService.ts
@@ -162,8 +162,6 @@ export class QueryService {
         }
       }
 
-      console.log("test env?", this.testEnv)
-
       // For some reason, the onSnapshot overload with three args (middle one
       // indicating to include metadata changes) doesn't return any snapshots in
       // the test environment. It works fine in the browser. Passing {

--- a/lib/QueryService.ts
+++ b/lib/QueryService.ts
@@ -113,9 +113,17 @@ export class QueryService {
 
       const unsubscribeFromQuery = onSnapshot(
         q,
-        { includeMetadataChanges: true },
         (querySnapshot) => {
-          if (querySnapshot.metadata.fromCache) return
+          if (querySnapshot.metadata.fromCache) {
+            this.log(
+              "Query",
+              queryKey,
+              "returned",
+              querySnapshot.size,
+              "cached docs; ignoring."
+            )
+            return
+          }
 
           const docs: CachedDocument[] = []
 

--- a/lib/QueryService.ts
+++ b/lib/QueryService.ts
@@ -113,7 +113,10 @@ export class QueryService {
 
       const unsubscribeFromQuery = onSnapshot(
         q,
+        { includeMetadataChanges: true },
         (querySnapshot) => {
+          if (querySnapshot.metadata.fromCache) return
+
           const docs: CachedDocument[] = []
 
           this.log(
@@ -123,7 +126,8 @@ export class QueryService {
             querySnapshot.size,
             "docs for",
             this.queryListenersByKey[queryKey].length,
-            "listeners"
+            "listeners",
+            querySnapshot.metadata
           )
 
           querySnapshot.forEach((docSnapshot) => {

--- a/lib/helpers/chunk.ts
+++ b/lib/helpers/chunk.ts
@@ -1,0 +1,89 @@
+import slice from "./slice"
+
+/**
+ * The MIT License
+ *
+ * Copyright JS Foundation and other contributors <https://js.foundation/>
+ *
+ * Based on Underscore.js, copyright Jeremy Ashkenas,
+ * DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals. For exact contribution history, see the revision history
+ * available at https://github.com/lodash/lodash
+ *
+ * The following license applies to all parts of this software except as
+ * documented below:
+ *
+ * ====
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * ====
+ *
+ * Copyright and related rights for sample code are waived via CC0. Sample
+ * code is defined as all source code displayed within the prose of the
+ * documentation.
+ *
+ * CC0: http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * ====
+ *
+ * Files located in the node_modules and vendor directories are externally
+ * maintained libraries used by this software which have their own
+ * licenses; we recommend you read them, as their terms may differ from the
+ * terms above.
+ */
+
+/**
+ * Creates an array of elements split into groups the length of `size`.
+ * If `array` can't be split evenly, the final chunk will be the remaining
+ * elements.
+ *
+ * @since 3.0.0
+ * @category Array
+ * @param {Array} array The array to process.
+ * @param {number} [size=1] The length of each chunk
+ * @returns {Array} Returns the new array of chunks.
+ * @example
+ *
+ * chunk(['a', 'b', 'c', 'd'], 2)
+ * // => [['a', 'b'], ['c', 'd']]
+ *
+ * chunk(['a', 'b', 'c', 'd'], 3)
+ * // => [['a', 'b', 'c'], ['d']]
+ */
+function chunk<T>(array: T[], size = 1) {
+  size = Math.max(size, 0)
+  const length = array == null ? 0 : array.length
+  if (!length || size < 1) {
+    return []
+  }
+  let index = 0
+  let resIndex = 0
+  const result = new Array(Math.ceil(length / size)) as T[][]
+
+  while (index < length) {
+    result[resIndex++] = slice(array, index, (index += size))
+  }
+  return result
+}
+
+export default chunk

--- a/lib/helpers/difference.ts
+++ b/lib/helpers/difference.ts
@@ -1,0 +1,6 @@
+export function difference<T>(a: T[], b: T[]) {
+  const set = new Set(b)
+  return a.filter(function (x) {
+    return !set.has(x)
+  })
+}

--- a/lib/helpers/index.ts
+++ b/lib/helpers/index.ts
@@ -1,0 +1,3 @@
+export * from "./chunk"
+export * from "./intersect"
+export * from "./difference"

--- a/lib/helpers/intersect.ts
+++ b/lib/helpers/intersect.ts
@@ -29,15 +29,14 @@ function default_hash<T>(x: T): T {
 }
 
 /**
- * Takes an array of arrays and optionnally a hash function,
- * and returns the elements that are present in all the arrays.
- * When intersecting arrays of objects, you should use a custom
- * hash function that returns identical values when given objects
- * that should be considered equal in your application.
- * The default hash function is the identity function.
- * When performance is not critical, a handy hash function can be `JSON.stringify`.
+ * Takes an array of arrays and optionally a hash function, and returns the
+ * elements that are present in all the arrays. When intersecting arrays of
+ * objects, you should use a custom hash function that returns identical values
+ * when given objects that should be considered equal in your application. The
+ * default hash function is the identity function. When performance is not
+ * critical, a handy hash function can be `JSON.stringify`.
  */
-export default function intersect<T>(
+export function intersect<T>(
   arrays: ReadonlyArray<T>[],
   hash = default_hash
 ): T[] {

--- a/lib/helpers/slice.ts
+++ b/lib/helpers/slice.ts
@@ -1,0 +1,99 @@
+/**
+ * The MIT License
+ *
+ * Copyright JS Foundation and other contributors <https://js.foundation/>
+ *
+ * Based on Underscore.js, copyright Jeremy Ashkenas,
+ * DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals. For exact contribution history, see the revision history
+ * available at https://github.com/lodash/lodash
+ *
+ * The following license applies to all parts of this software except as
+ * documented below:
+ *
+ * ====
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * ====
+ *
+ * Copyright and related rights for sample code are waived via CC0. Sample
+ * code is defined as all source code displayed within the prose of the
+ * documentation.
+ *
+ * CC0: http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * ====
+ *
+ * Files located in the node_modules and vendor directories are externally
+ * maintained libraries used by this software which have their own
+ * licenses; we recommend you read them, as their terms may differ from the
+ * terms above.
+ */
+
+/**
+ * Creates a slice of `array` from `start` up to, but not including, `end`.
+ *
+ * **Note:** This method is used instead of
+ * [`Array#slice`](https://mdn.io/Array/slice) to ensure dense arrays are
+ * returned.
+ *
+ * @since 3.0.0
+ * @category Array
+ * @param {Array} array The array to slice.
+ * @param {number} [start=0] The start position. A negative index will be treated as an offset from the end.
+ * @param {number} [end=array.length] The end position. A negative index will be treated as an offset from the end.
+ * @returns {Array} Returns the slice of `array`.
+ * @example
+ *
+ * var array = [1, 2, 3, 4]
+ *
+ * _.slice(array, 2)
+ * // => [3, 4]
+ */
+function slice<T>(array: T[], start: number, end: number) {
+  let length = array == null ? 0 : array.length
+  if (!length) {
+    return []
+  }
+  start = start == null ? 0 : start
+  end = end === undefined ? length : end
+
+  if (start < 0) {
+    start = -start > length ? 0 : length + start
+  }
+  end = end > length ? length : end
+  if (end < 0) {
+    end += length
+  }
+  length = start > end ? 0 : (end - start) >>> 0
+  start >>>= 0
+
+  let index = -1
+  const result = new Array(length) as T[]
+  while (++index < length) {
+    result[index] = array[index + start]
+  }
+  return result
+}
+
+export default slice

--- a/lib/serializeQuery.ts
+++ b/lib/serializeQuery.ts
@@ -69,6 +69,12 @@ export function serializeQuery(query: Query<DocumentData>) {
   }
 }
 
+export function getQueryPath(query: Query<DocumentData>) {
+  const { _query } = query as Firestore3Query
+
+  return _query.path.segments.join("/")
+}
+
 /**
  * Serialize a single Firebase filter. Returns something like:
  *

--- a/lib/useDocs.test.tsx
+++ b/lib/useDocs.test.tsx
@@ -179,7 +179,9 @@ describe("useDocs", () => {
     const { getAllByRole } = render(
       <ListRepos ownerId={repo1.ownerId} />,
       {
-        wrapper: DocsProvider,
+        wrapper: ({ children }) => (
+          <DocsProvider testEnv>{children}</DocsProvider>
+        ),
       }
     )
 
@@ -207,7 +209,9 @@ describe("useDocs", () => {
     const { getAllByRole, getByText } = render(
       <ListRepos ownerId={repo.ownerId} />,
       {
-        wrapper: DocsProvider,
+        wrapper: ({ children }) => (
+          <DocsProvider testEnv>{children}</DocsProvider>
+        ),
       }
     )
 

--- a/lib/useDocs.ts
+++ b/lib/useDocs.ts
@@ -112,6 +112,14 @@ export function useDoc<T extends { id: string }>(
       return { ...doc, ...updates }
     })
 
+    log(
+      "updating",
+      ref.path,
+      "fields:",
+      Object.keys(updates).join(", "),
+      "..."
+    )
+
     await updateDoc(ref, updates as DocumentData)
   }
 

--- a/lib/useDocs.ts
+++ b/lib/useDocs.ts
@@ -128,10 +128,10 @@ export function useDoc<T extends { id: string }>(
 
 export function useDocs<T extends { id: string }>(
   collection: CollectionReference,
-  ids: string[]
+  ids: string[] | undefined
 ) {
   const [docs, setDocs] = useState<T[] | undefined>(() => {
-    return ids.length < 1 ? [] : undefined
+    return !ids || ids.length < 1 ? [] : undefined
   })
   const hookId = useHookId(collection, ids)
   const service = useCollectionService("useDoc")
@@ -145,37 +145,44 @@ export function useDocs<T extends { id: string }>(
     []
   )
 
-  useEffect(() => {
-    setDocs(ids.length < 1 ? [] : undefined)
+  useEffect(
+    function registerHook() {
+      setDocs(!ids || ids.length < 1 ? [] : undefined)
 
-    const { unregister, cachedDocs } = service.registerDocsHook(
-      hookId,
-      collection,
-      ids,
-      (docs) => {
-        if (!mountedRef.current) return
+      const { unregister, cachedDocs } =
+        service.registerDocsHook(
+          hookId,
+          collection,
+          ids ?? [],
+          (docs) => {
+            if (!mountedRef.current) return
 
-        setDocs(docs as unknown as T[])
+            setDocs(docs as unknown as T[])
+          }
+        )
+
+      if (cachedDocs) {
+        setDocs(cachedDocs as unknown as T[])
       }
-    )
 
-    if (cachedDocs) {
-      setDocs(cachedDocs as unknown as T[])
-    }
+      return unregister
+    },
+    [collection.path]
+  )
 
-    return unregister
-  }, [collection.path])
+  useEffect(
+    function updateDocIds() {
+      if (firstRenderRef.current) {
+        firstRenderRef.current = false
+        return
+      }
 
-  useEffect(() => {
-    if (firstRenderRef.current) {
-      firstRenderRef.current = false
-      return
-    }
+      setDocs(!ids || ids.length < 1 ? [] : undefined)
 
-    setDocs(ids.length < 1 ? [] : undefined)
-
-    service.updateDocIds(collection.path, hookId, ids)
-  }, [ids.join()])
+      service.updateDocIds(collection.path, hookId, ids ?? [])
+    },
+    [ids?.join()]
+  )
 
   return docs
 }

--- a/lib/useDocs.ts
+++ b/lib/useDocs.ts
@@ -113,7 +113,7 @@ export function useDoc<T extends { id: string }>(
     })
 
     log(
-      "updating",
+      "Updating",
       ref.path,
       "fields:",
       Object.keys(updates).join(", "),
@@ -154,6 +154,7 @@ export function useDocs<T extends { id: string }>(
       ids,
       (docs) => {
         if (!mountedRef.current) return
+
         setDocs(docs as unknown as T[])
       }
     )

--- a/lib/useHookId.ts
+++ b/lib/useHookId.ts
@@ -5,7 +5,7 @@ import type {
 } from "firebase/firestore"
 import { useState } from "react"
 import { useQueryService } from "./DocsProvider"
-import { serializeQuery } from "./serializeQuery"
+import { getQueryPath, serializeQuery } from "./serializeQuery"
 
 let hookCount = 0
 
@@ -25,6 +25,9 @@ const IGNORE_FUNCTIONS = [
   "renderWithHooks",
   "useState",
   "Object.useState",
+  "mountIndeterminateComponent",
+  "Module.useHookId",
+  "Proxy.useState",
 ]
 
 /**
@@ -73,15 +76,24 @@ export function useHookId(
       loc = functionNames?.join(">")
     }
 
+    const path =
+      typeof context === "string"
+        ? ""
+        : isCollectionReference(context)
+        ? context.path
+        : isDocumentReference(context)
+        ? context.path
+        : getQueryPath(context)
+
     if (loc) {
       if (typeof context === "string") {
         return `${context}@${loc} #${++hookCount}`
       } else if (isDocumentReference(context)) {
-        return `useDoc@${loc} #${++hookCount}`
+        return `${loc}(${path}) #${++hookCount}`
       } else if (isCollectionReference(context)) {
-        return `useDocs@${loc} #${++hookCount}`
+        return `${loc}(${path}) #${++hookCount}`
       } else {
-        return `useQuery@${loc} #${++hookCount}`
+        return `${loc}(${path}) #${++hookCount}`
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-firestore",
-  "version": "0.17.0-beta.2",
+  "version": "0.17.0-beta.3",
   "license": "MIT",
   "main": "./dist/lib.umd.js",
   "module": "./dist/lib.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-firestore",
-  "version": "0.16.0-beta.0",
+  "version": "0.17.0-beta.0",
   "license": "MIT",
   "main": "./dist/lib.umd.js",
   "module": "./dist/lib.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-firestore",
-  "version": "0.17.0-beta.0",
+  "version": "0.17.0-beta.1",
   "license": "MIT",
   "main": "./dist/lib.umd.js",
   "module": "./dist/lib.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-firestore",
-  "version": "0.17.0-beta.1",
+  "version": "0.17.0-beta.2",
   "license": "MIT",
   "main": "./dist/lib.umd.js",
   "module": "./dist/lib.es.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-firestore",
-  "version": "0.15.0",
+  "version": "0.16.0-beta.0",
   "license": "MIT",
   "main": "./dist/lib.umd.js",
   "module": "./dist/lib.es.js",


### PR DESCRIPTION
Turns out Firestore has a hard limit of 30 ids for an `"in"` query. This PR adds a batching mechanism to the `CollectionService` to get around that.